### PR TITLE
fix sector orientation; 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ unreleased
 ------------------------
 Added
 ~~~~~~
+* extra geojson serializer for trip
 Changed
 ~~~~~~~~
 Deprecated
@@ -13,6 +14,7 @@ Removed
 ~~~~~~~~~
 Fixed
 ~~~~~~~~
+* automatic sector orientations should point inward
 Security
 ~~~~~~~~~
 

--- a/opensoar/task/task.py
+++ b/opensoar/task/task.py
@@ -30,6 +30,8 @@ class Task:
         self.start_time_buffer = start_time_buffer
         self.multistart = multistart
 
+        # TODO: wouldn't this be better set in waypoint initialization?
+        # reason could be line cross logic depending on "next" and "previous"
         self.set_orientation_angles(self.waypoints)
 
     def __eq__(self, other):
@@ -72,19 +74,15 @@ class Task:
         for index in range(len(waypoints)):
 
             if index == 0:  # necessary for index out of bounds
-                _, angle = calculate_distance_bearing(waypoints[index + 1].fix, waypoints[index].fix,
-                                                      final_bearing=True)
+                _, angle = calculate_distance_bearing(waypoints[index].fix, waypoints[index + 1].fix)
                 waypoints[index].set_orientation_angle(angle_next=angle)
             elif index == len(waypoints) - 1:  # necessary for index out of bounds
-                _, angle = calculate_distance_bearing(waypoints[index - 1].fix, waypoints[index].fix,
-                                                      final_bearing=True)
+                _, angle = calculate_distance_bearing(waypoints[index].fix, waypoints[index - 1].fix)
                 waypoints[index].set_orientation_angle(angle_previous=angle)
             else:
-                _, angle_start = calculate_distance_bearing(waypoints[0].fix, waypoints[index].fix, final_bearing=True)
-                _, angle_previous = calculate_distance_bearing(waypoints[index - 1].fix, waypoints[index].fix,
-                                                               final_bearing=True)
-                _, angle_next = calculate_distance_bearing(waypoints[index + 1].fix, waypoints[index].fix,
-                                                           final_bearing=True)
+                _, angle_start = calculate_distance_bearing(waypoints[index].fix, waypoints[0].fix)
+                _, angle_previous = calculate_distance_bearing(waypoints[index].fix, waypoints[index - 1].fix)
+                _, angle_next = calculate_distance_bearing(waypoints[index].fix, waypoints[index + 1].fix)
                 waypoints[index].set_orientation_angle(angle_start=angle_start,
                                                        angle_previous=angle_previous,
                                                        angle_next=angle_next)

--- a/opensoar/task/task.py
+++ b/opensoar/task/task.py
@@ -30,8 +30,6 @@ class Task:
         self.start_time_buffer = start_time_buffer
         self.multistart = multistart
 
-        # TODO: wouldn't this be better set in waypoint initialization?
-        # reason could be line cross logic depending on "next" and "previous"
         self.set_orientation_angles(self.waypoints)
 
     def __eq__(self, other):

--- a/opensoar/task/waypoint.py
+++ b/opensoar/task/waypoint.py
@@ -118,8 +118,8 @@ class Waypoint(object):
                 angle_wrt_orientation2 = abs(calculate_bearing_difference(self.orientation_angle, bearing2))
 
                 if self.sector_orientation == "next":  # start line
-                    return angle_wrt_orientation1 < 90 < angle_wrt_orientation2
-                elif self.sector_orientation == "previous":  # finish line
                     return angle_wrt_orientation2 < 90 < angle_wrt_orientation1
+                elif self.sector_orientation == "previous":  # finish line
+                    return angle_wrt_orientation1 < 90 < angle_wrt_orientation2
                 else:
                     raise ValueError("A line with this orientation is not implemented!")

--- a/opensoar/task/waypoint.py
+++ b/opensoar/task/waypoint.py
@@ -40,6 +40,10 @@ class Waypoint(object):
         self.orientation_angle = orientation_angle
 
         self.is_line = is_line
+
+        if sector_orientation not in {'fixed', 'symmetrical', 'next', 'previous', 'start'}:
+            raise ValueError('sector_orientation value not supported')
+
         self.sector_orientation = sector_orientation
         self.distance_correction = distance_correction
 

--- a/opensoar/utilities/geojson_serializers.py
+++ b/opensoar/utilities/geojson_serializers.py
@@ -72,7 +72,13 @@ def task_to_geojson_features(task) -> List[dict]:
     return features
 
 
-def trip_to_geojson_features(trip, color) -> List[dict]:
+def trip_to_geojson_features(trip, color: str) -> List[dict]:
+    """
+    :param trip:
+    :param color: hex string with leading hashtag (e.g. "#062123")
+    :return:
+    """
+
     features = []
 
     for sector in trip.sector_fixes:

--- a/tests/competition/test_soaringspot.py
+++ b/tests/competition/test_soaringspot.py
@@ -118,6 +118,9 @@ class TestSoaringspot(unittest.TestCase):
             ("SALLAND FL", 84, False),
         ]
 
+        wp = waypoints[0]
+        print(wp.r_min, wp.angle_min, wp.r_max, wp.angle_max)
+
         for w, expected_w in zip(waypoints, expected):
             name, orientation_angle, is_line = expected_w
             self.assertEqual(w.name, name)

--- a/tests/competition/test_soaringspot.py
+++ b/tests/competition/test_soaringspot.py
@@ -5,6 +5,7 @@ import datetime
 from opensoar.competition.soaringspot import get_lat_long, get_fixed_orientation_angle, get_sector_orientation, \
     get_sector_dimensions, get_waypoint, get_waypoints, SoaringSpotDaily, get_task_rules
 from opensoar.task.waypoint import Waypoint
+from opensoar.task.task import Task
 
 
 class TestSoaringspot(unittest.TestCase):
@@ -104,12 +105,24 @@ class TestSoaringspot(unittest.TestCase):
         ]
 
         waypoints = get_waypoints(lcu_lines, lseeyou_lines)
+        Task.set_orientation_angles(waypoints)
+
         self.assertEqual(len(waypoints), 5)
 
-        for waypoint in waypoints:
-            self.assertTrue(isinstance(waypoint, Waypoint))
+        # name, orientation_angle, is_line
+        expected = [
+            ("SALLAND AF1", 209, True),
+            ("Deventer", 81, False),
+            ("Ruurlo", 335, False),
+            ("Archemerberg", 220, False),
+            ("SALLAND FL", 84, False),
+        ]
 
-        self.assertEqual(waypoints[2].name, 'Ruurlo')
+        for w, expected_w in zip(waypoints, expected):
+            name, orientation_angle, is_line = expected_w
+            self.assertEqual(w.name, name)
+            self.assertEqual(int(w.orientation_angle), orientation_angle)
+            self.assertEqual(w.is_line, is_line)
 
     def test_get_competitors(self):
         soaringspot_page = SoaringSpotDaily(

--- a/tests/task/test_waypoint.py
+++ b/tests/task/test_waypoint.py
@@ -23,7 +23,7 @@ class TestWaypoint(unittest.TestCase):
         # - outer quarter circle segment (angle_min=45)
 
         wp = Waypoint('testwaypoint', latitude=52, longitude=1, r_min=5000, angle_min=90, r_max=10000,
-                      angle_max=45, is_line=False, sector_orientation='fixes', distance_correction=None,
+                      angle_max=45, is_line=False, sector_orientation='fixed', distance_correction=None,
                       orientation_angle=180)
 
         point_in_inner_sector = calculate_destination(wp.fix, 3000, 80)
@@ -78,3 +78,57 @@ class TestWaypoint(unittest.TestCase):
 
         for waypoint in waypoints:
             self.assertFalse(waypoint == waypoint1)
+
+    def test_crossed_start_line(self):
+        """
+        Test whether points in correct order trigger line crossing
+        Start line is W-E oriented, with a point north first and then a point south should be a start
+        """
+        # start line is pointing sout
+
+        start_line = Waypoint('testwaypoint', latitude=52, longitude=1, r_min=None, angle_min=None, r_max=1000,
+                      angle_max=45, is_line=True, sector_orientation='next', distance_correction=None,
+                      orientation_angle=180)
+
+        # test direction of crossing
+        point_north = calculate_destination(start_line.fix, 1000, 0)
+        point_south = calculate_destination(start_line.fix, 1000, 180)
+        self.assertTrue(start_line.crossed_line(point_north, point_south))
+        self.assertFalse(start_line.crossed_line(point_south, point_north))
+
+        # test within radius of line
+        point_north_close = calculate_destination(start_line.fix, 500, 45)
+        point_south_close = calculate_destination(start_line.fix, 500, 135)
+        self.assertTrue(start_line.crossed_line(point_north_close, point_south_close))
+
+        # test outside radius of line
+        point_north_far = calculate_destination(start_line.fix, 2000, 45)
+        point_south_far = calculate_destination(start_line.fix, 2000, 135)
+        self.assertFalse(start_line.crossed_line(point_north_far, point_south_far))
+
+    def test_crossed_finish_line(self):
+        """
+        Test whether points in correct order trigger line crossing
+        Finish line is W-E oriented, with a point north first and then a point south should be a finish
+        """
+        # start line is pointing sout
+
+        finish_line = Waypoint('testwaypoint', latitude=52, longitude=1, r_min=None, angle_min=None, r_max=1000,
+                      angle_max=45, is_line=True, sector_orientation='previous', distance_correction=None,
+                      orientation_angle=0)
+
+        # test direction of crossing
+        point_north = calculate_destination(finish_line.fix, 1000, 0)
+        point_south = calculate_destination(finish_line.fix, 1000, 180)
+        self.assertTrue(finish_line.crossed_line(point_north, point_south))
+        self.assertFalse(finish_line.crossed_line(point_south, point_north))
+
+        # test within radius of line
+        point_north_close = calculate_destination(finish_line.fix, 500, 45)
+        point_south_close = calculate_destination(finish_line.fix, 500, 135)
+        self.assertTrue(finish_line.crossed_line(point_north_close, point_south_close))
+
+        # test outside radius of line
+        point_north_far = calculate_destination(finish_line.fix, 2000, 45)
+        point_south_far = calculate_destination(finish_line.fix, 2000, 135)
+        self.assertFalse(finish_line.crossed_line(point_north_far, point_south_far))


### PR DESCRIPTION
with symmetrical sector orientation, the orientation should point inward. the cause of the orientation pointing outward was that previous and next were reversed. incidentally another bug with fixed orientation angles hid this problem. fixing these fixed orientation angles recently brought up this problem. also had to change line cross logic

this MR closes #45 

remaining:
- [x] add test: from L lines in IGC -> correct waypoint definitions
- [x] add test: line crossings start and finish
- [x] consider moving sector orientation setting logic
- [x] changelog