### PR TITLE
Pressure altitude correction based on takeoff elevation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ unreleased
 ------------------------
 Added
 ~~~~~~
+* Pressure altitude correction based on takeoff elevation
 Changed
 ~~~~~~~~
 Deprecated

--- a/opensoar/competition/soaringspot.py
+++ b/opensoar/competition/soaringspot.py
@@ -64,6 +64,7 @@ def get_info_from_comment_lines(parsed_igc_file: dict, start_time_buffer: int=0)
     t_min = None
     start_opening = None
     multi_start = False
+    takeoff_elevation = None
 
     for line in comment_lines:
         if line.startswith('LCU::C'):
@@ -82,21 +83,24 @@ def get_info_from_comment_lines(parsed_igc_file: dict, start_time_buffer: int=0)
             start_opening, t_min, multi_start = get_task_rules(line)
         elif line.startswith('LCU::HPTZNTIMEZONE:'):
             timezone = int(line.split(':')[3])
+        elif line.startswith('LCU::HPELVELEVATION:'):
+            takeoff_elevation = int(line.split(':')[3])
 
     if start_opening is not None:
         # convert start opening to UTC time
         start_opening = subtract_times(start_opening, datetime.timedelta(hours=timezone))
+
 
     if len(lcu_lines) == 0 or len(lseeyou_lines) == 0:
         # somehow some IGC files do not contain the LCU or LSEEYOU lines with task information
         task = None
     else:
         waypoints = get_waypoints(lcu_lines, lseeyou_lines)
-
         if t_min is None:
-            task = RaceTask(waypoints, timezone, start_opening, start_time_buffer, multi_start)
+            task = RaceTask(waypoints, timezone, start_opening, start_time_buffer, multi_start, takeoff_elevation)
         else:
-            task = AAT(waypoints, t_min, timezone, start_opening, start_time_buffer, multi_start)
+            task = AAT(waypoints, t_min, timezone, start_opening, start_time_buffer, multi_start, takeoff_elevation)
+
 
     return task, contest_information, competitor_information
 

--- a/opensoar/task/aat.py
+++ b/opensoar/task/aat.py
@@ -12,7 +12,7 @@ class AAT(Task):
     """
 
     def __init__(self, waypoints, t_min: datetime.timedelta, timezone: int=None, start_opening: datetime.time=None,
-                 start_time_buffer: int=0, multistart: bool=False):
+                 start_time_buffer: int=0, multistart: bool=False, takeoff_elevation: int=None):
         """
         :param waypoints:           see super()
         :param t_min:               minimal time to complete task
@@ -20,8 +20,9 @@ class AAT(Task):
         :param start_opening:       see super()
         :param start_time_buffer:   see super()
         :param multistart:          see super()
+        :param takeoff_elevation:   see super()
         """
-        super().__init__(waypoints, timezone, start_opening, start_time_buffer, multistart)
+        super().__init__(waypoints, timezone, start_opening, start_time_buffer, multistart, takeoff_elevation)
 
         self._t_min = t_min
         self._nominal_distances = self._calculate_nominal_distances()

--- a/opensoar/task/race_task.py
+++ b/opensoar/task/race_task.py
@@ -8,15 +8,17 @@ class RaceTask(Task):
     Race task.
     """
 
-    def __init__(self, waypoints, timezone=None, start_opening=None, start_time_buffer=0, multistart=False):
+    def __init__(self, waypoints, timezone=None, start_opening=None, start_time_buffer=0, multistart=False,
+                 takeoff_elevation=None):
         """
         :param waypoints:           see super()
         :param timezone:            see super()
         :param start_opening:       see super()
         :param start_time_buffer:   see super()
         :param multistart:          see super()
+        :param takeoff_elevation:   see super()
         """
-        super().__init__(waypoints, timezone, start_opening, start_time_buffer, multistart)
+        super().__init__(waypoints, timezone, start_opening, start_time_buffer, multistart, takeoff_elevation)
 
         self.distances = self.calculate_task_distances()
 

--- a/opensoar/task/task.py
+++ b/opensoar/task/task.py
@@ -15,13 +15,14 @@ class Task:
     ENL_TIME_THRESHOLD = 30
 
     def __init__(self, waypoints: List[Waypoint], timezone: int, start_opening: datetime.time, start_time_buffer: int,
-                 multistart: bool):
+                 multistart: bool, takeoff_elevation: int):
         """
         :param waypoints:
         :param timezone: time difference wrt UTC in hours
         :param start_opening: in UTC
         :param start_time_buffer: in seconds
         :param multistart: flag whether multistart takes place
+        :param takeoff_elevation: elevation of takeoff airfield
         """
 
         self._waypoints = waypoints
@@ -29,6 +30,7 @@ class Task:
         self.start_opening = start_opening
         self.start_time_buffer = start_time_buffer
         self.multistart = multistart
+        self.takeoff_elevation = takeoff_elevation
 
         self.set_orientation_angles(self.waypoints)
 

--- a/opensoar/task/trip.py
+++ b/opensoar/task/trip.py
@@ -1,4 +1,4 @@
-from opensoar.utilities.helper_functions import seconds_time_difference
+from opensoar.utilities.helper_functions import seconds_time_difference, apply_takeoff_elevation_delta
 
 
 class Trip:
@@ -9,6 +9,10 @@ class Trip:
     def __init__(self, task, trace):
 
         task_result = task.apply_rules(trace)
+
+        if task.takeoff_elevation is not None:
+            max_ground_fixes = 1000
+            task_result = apply_takeoff_elevation_delta(trace[0:max_ground_fixes], task_result, task.takeoff_elevation)
 
         self.fixes = task_result[0]
         self.refined_start_time = task_result[1]

--- a/opensoar/utilities/helper_functions.py
+++ b/opensoar/utilities/helper_functions.py
@@ -1,6 +1,6 @@
 from copy import copy
 from math import isclose, pi, sin, cos, atan2
-from statistics import mean
+from statistics import median
 
 import datetime
 from typing import List
@@ -287,7 +287,7 @@ def takeoff_elevation_delta(trace, takeoff_elevation):
         if dist/delta_t < takeoff_speed_thres:
             alt_ground.append(trace[n]['pressure_alt'])
 
-    return takeoff_elevation - int(mean(alt_ground))
+    return takeoff_elevation - int(median(alt_ground))
 
 
 def apply_takeoff_elevation_delta(trace, task_result, takeoff_elevation):

--- a/opensoar/utilities/helper_functions.py
+++ b/opensoar/utilities/helper_functions.py
@@ -1,5 +1,6 @@
 from copy import copy
 from math import isclose, pi, sin, cos, atan2
+from statistics import mean
 
 import datetime
 from typing import List
@@ -269,3 +270,32 @@ def both_none_or_same_str(var1, var2):
         return var2 is None
     else:
         return var2 is not None and var1 == var2
+
+
+def takeoff_elevation_delta(trace, takeoff_elevation):
+    """Determine the difference in pre-takeoff pressure altitude (averaged over before takeoff fixes) to takeoff
+    elevation as given in igc file"""
+
+    # Ground speed threshold in m/s
+    takeoff_speed_thres = 5.
+
+    # Determine points before takeoff
+    alt_ground = []
+    for n in range(len(trace)-1):
+        dist, _ = calculate_distance_bearing(trace[n], trace[n+1])
+        delta_t = int(seconds_time_difference(trace[n]['time'], trace[n+1]['time']))
+        if dist/delta_t < takeoff_speed_thres:
+            alt_ground.append(trace[n]['pressure_alt'])
+
+    return takeoff_elevation - int(mean(alt_ground))
+
+
+def apply_takeoff_elevation_delta(trace, task_result, takeoff_elevation):
+    """Apply takeoff elevation delta to all turn point fixes"""
+
+    elevation_delta = takeoff_elevation_delta(trace, takeoff_elevation)
+
+    for n_tp, tp_fix in enumerate(task_result[0]):
+        task_result[0][n_tp]['pressure_alt'] = tp_fix['pressure_alt'] + elevation_delta
+
+    return task_result

--- a/tests/task/test_trip.py
+++ b/tests/task/test_trip.py
@@ -38,6 +38,10 @@ class TestTrip(unittest.TestCase):
         finish_fix = self.trip.fixes[-1]
         self.assertEqual(finish_fix['time'], datetime.time(13, 21, 58))
 
+    def test_elevation_correction(self):
+        start_fix = self.trip.fixes[0]
+        self.assertEqual(start_fix['pressure_alt'], 1059)
+
 
 class TestOutlandingTrip(unittest.TestCase):
     """


### PR DESCRIPTION
This PR picks up [#161](https://github.com/GliderGeek/PySoar/pull/161) in the PySoar repo. 

Instead of manually entering takeoff elevation, it reads it from the igc file, as soaringspot writes takeoff elevation into the file (see `LCU::HPELVELEVATION`). An altitude correction is calculated by comparing it to the median pre-takeoff pressure altitude. Pre-takeoff fixes are determined via a groundspeed threshold. 

This correction is subsequently applied to all pressure altitudes in `task_results`, resulting in better comparability in altitudes at turnpoints.