### PR TITLE
CI Workflow Update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Package
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.9'
+
+    - name: Build distribution
+      run: |
+        python -m pip install --upgrade build
+        python -m build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,29 +1,24 @@
-name: Test
+name: Run Tests
 
 on:
-  push
+  workflow_call:
 
 jobs:
-
-  build:
-    name: Test
+  test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout code
+      uses: actions/checkout@v5
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: '3.9'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+
     - name: Run tests
       run: python -m unittest discover -b --start-directory ./tests
-    - name: build dist
-      run: python3 -m pip install --upgrade build && python3 -m build
-    - name: Publish package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test_trigger.yml
+++ b/.github/workflows/test_trigger.yml
@@ -1,0 +1,9 @@
+name: Test Trigger
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Example race task
     with open('example.igc', 'r') as f:
         parsed_igc_file = Reader().read(f)
 
-    # example.igc comes from soaringspot and contains task inforamtion
+    # example.igc comes from soaringspot and contains task information
     task, _, _ = get_info_from_comment_lines(parsed_igc_file)
     _, trace = parsed_igc_file['fix_records']
     


### PR DESCRIPTION
PR updates CI WorkFlow:
- added two new workflows: one reusable test workflow (`test.yml`) and one trigger (`test-trigger.yml`) that runs tests on every push and pull request
- the publish workflow (`publish.yml`) is unchanged but now depends on tests passing before publishing
- this setup avoids duplication and ensures consistent testing before deployment