### PR TITLE
Fix restart detection after passing a turnpoint (issue #64)

### DIFF
--- a/opensoar/task/aat.py
+++ b/opensoar/task/aat.py
@@ -73,9 +73,9 @@ class AAT(Task):
             finish_time = fixes[-1]['datetime']
         return finish_time
 
-    def _calculate_trip_fixes(self, trace):
+    def _calculate_trip_fixes(self, trace, _allow_late_restart=True):
 
-        sector_fixes, enl_outlanding_fix = self._get_sector_fixes(trace)
+        sector_fixes, enl_outlanding_fix, restart_candidates = self._get_sector_fixes(trace, _allow_late_restart)
         reduced_sector_fixes = self._reduce_sector_fixes(sector_fixes, max_fixes_sector=300)
 
         outlanded = len(sector_fixes) != self.no_legs+1
@@ -102,7 +102,23 @@ class AAT(Task):
             trip_fixes = max_distance_fixes
             outlanding_fix = None
 
-        return trip_fixes, outlanding_fix, sector_fixes
+        if not restart_candidates:
+            return trip_fixes, outlanding_fix, sector_fixes
+
+        orig_distance = sum(self._determine_trip_distances(trip_fixes, outlanding_fix))
+        best = (trip_fixes, outlanding_fix, sector_fixes, orig_distance)
+
+        for restart_idx in restart_candidates:
+            c_trip_fixes, c_outlanding_fix, c_sector_fixes = self._calculate_trip_fixes(
+                trace[restart_idx:], _allow_late_restart=False
+            )
+            if not c_trip_fixes:
+                continue
+            c_distance = sum(self._determine_trip_distances(c_trip_fixes, c_outlanding_fix))
+            if c_distance > best[3]:
+                best = (c_trip_fixes, c_outlanding_fix, c_sector_fixes, c_distance)
+
+        return best[0], best[1], best[2]
 
     def _determine_trip_distances(self, fixes, outlanding_fix):
 
@@ -118,14 +134,15 @@ class AAT(Task):
 
         return distances
 
-    def _get_sector_fixes(self, trace):
+    def _get_sector_fixes(self, trace, _allow_late_restart=True):
 
         current_leg = -1  # not yet started
         sector_fixes = list()
         enl_first_fix = None
         enl_registered = False
+        restart_candidates = []
 
-        for fix_minus1, fix in double_iterator(trace):
+        for pair_idx, (fix_minus1, fix) in enumerate(double_iterator(trace)):
 
             # check ENL when aircraft logs ENL and no ENL outlanding has taken place
             if not enl_registered and self.enl_value_exceeded(fix):
@@ -158,7 +175,9 @@ class AAT(Task):
                     self._add_aat_sector_fix(sector_fixes, 1, fix_minus1)
                     current_leg += 1
             elif 0 < current_leg < self.no_legs - 1:  # at least second leg, no re-start possible
-                if self.waypoints[current_leg].inside_sector(fix_minus1):  # previous waypoint
+                if _allow_late_restart and self.started(fix_minus1, fix):
+                    restart_candidates.append(pair_idx)
+                elif self.waypoints[current_leg].inside_sector(fix_minus1):  # previous waypoint
                     self._add_aat_sector_fix(sector_fixes, current_leg, fix_minus1)
                 elif self.waypoints[current_leg + 1].inside_sector(fix_minus1):  # next waypoint
                     self._add_aat_sector_fix(sector_fixes, current_leg + 1, fix_minus1)
@@ -177,9 +196,9 @@ class AAT(Task):
             sector_fixes[-1].append(last_fix)
 
         if enl_registered:
-            return sector_fixes, enl_first_fix
+            return sector_fixes, enl_first_fix, restart_candidates
         else:
-            return sector_fixes, None
+            return sector_fixes, None, restart_candidates
 
     def _reduce_fixes(self, fixes, max_fixes):
         reduction_factor = len(fixes) // max_fixes + 1

--- a/opensoar/task/race_task.py
+++ b/opensoar/task/race_task.py
@@ -86,7 +86,7 @@ class RaceTask(Task):
         sector_fixes = []  # not applicable for race tasks
         return fixes, refined_start, outlanding_fix, distances, finish_time, sector_fixes
 
-    def determine_trip_fixes(self, trace):
+    def determine_trip_fixes(self, trace, _allow_late_restart=True):
 
         leg = -1
         enl_first_fix = None
@@ -94,7 +94,9 @@ class RaceTask(Task):
 
         fixes = list()
         start_fixes = list()
-        for fix_minus1, fix in double_iterator(trace):
+        restart_candidates = []  # trace indices where started() fired at leg > 0
+
+        for pair_idx, (fix_minus1, fix) in enumerate(double_iterator(trace)):
 
             if not enl_registered and self.enl_value_exceeded(fix):
                 if enl_first_fix is None:
@@ -127,17 +129,38 @@ class RaceTask(Task):
                     fixes.append(fix)
                     leg += 1
             elif 0 < leg < self.no_legs:
-                if self.finished_leg(leg, fix_minus1, fix) and not enl_registered:
+                if _allow_late_restart and self.started(fix_minus1, fix):
+                    # Collect as challenger candidate; do not reset current attempt.
+                    # pair_idx == index of fix_minus1 in trace (double_iterator pair i → trace[i]).
+                    restart_candidates.append(pair_idx)
+                elif self.finished_leg(leg, fix_minus1, fix) and not enl_registered:
                     fixes.append(fix)
                     leg += 1
 
         enl_fix = enl_first_fix if enl_registered else None
 
-        outlanding_fix = None
-        if len(fixes) is not len(self.waypoints):
-            outlanding_fix = self.determine_outlanding_fix(trace, fixes, start_fixes, enl_fix)
+        orig_outlanding = None
+        if len(fixes) != len(self.waypoints):
+            orig_outlanding = self.determine_outlanding_fix(trace, fixes, start_fixes, enl_fix)
 
-        return fixes, outlanding_fix
+        if not restart_candidates:
+            return fixes, orig_outlanding
+
+        # Compare original attempt with every challenger by total scored distance.
+        orig_distance = sum(self.determine_trip_distances(fixes, orig_outlanding)) if fixes else 0
+        best_fixes, best_outlanding, best_distance = fixes, orig_outlanding, orig_distance
+
+        for restart_idx in restart_candidates:
+            c_fixes, c_outlanding = self.determine_trip_fixes(
+                trace[restart_idx:], _allow_late_restart=False
+            )
+            if not c_fixes:
+                continue
+            c_distance = sum(self.determine_trip_distances(c_fixes, c_outlanding))
+            if c_distance > best_distance:
+                best_fixes, best_outlanding, best_distance = c_fixes, c_outlanding, c_distance
+
+        return best_fixes, best_outlanding
 
     def determine_outlanding_fix(self, trace, fixes, start_fixes, enl_fix):
 

--- a/tests/task/test_task_rules.py
+++ b/tests/task/test_task_rules.py
@@ -1,0 +1,151 @@
+import os
+import datetime
+import unittest
+from unittest.mock import patch
+
+from tests.task.helper_functions import get_task
+
+
+class TestRestartAfterTurnpoint(unittest.TestCase):
+    """
+    FAI SC3A §7.4.3.6: multiple valid starts → scored using the start that yields the best score.
+    A start made after a properly completed task is not valid.
+
+    Tests call determine_trip_fixes directly with mocked started/finished_leg so that
+    the control-flow scenarios can be driven without needing real IGC flight geometry.
+    The side_effect lists are ordered by the exact call sequence produced by the implementation:
+      - main evaluation calls first, then challenger sub-evaluation calls.
+    """
+
+    cwd = os.path.dirname(__file__)
+    # 4-leg race task (no_legs=4, 5 waypoints)
+    igc_path = os.path.join(cwd, '..', 'igc_files', 'race_task_completed.igc')
+
+    def _make_fix(self, seconds):
+        return {
+            'datetime': datetime.datetime(2024, 1, 1, 12, 0, seconds,
+                                          tzinfo=datetime.timezone.utc),
+            'lat': 52.0,
+            'lon': 6.0,
+        }
+
+    def _load_task(self):
+        task = get_task(self.igc_path)
+        task.start_opening = None  # disable time-of-day filtering
+        return task
+
+    def test_restart_after_tp_leads_to_task_completion(self):
+        """
+        Case 2: pilot starts, rounds TP1, turns back, restarts, then completes the task.
+        The restart attempt scores because it achieves the full task distance.
+
+        Main evaluation (9 pairs over 10 fixes):
+          started calls:  T F F T F F F F F   (True at pair 0 = first start; True at pair 3 = candidate)
+          finished_leg:   T F F F F F F        (True at pair 1 = TP1 in main; rest False → outlanding leg 1)
+
+        Challenger sub-trace = trace[3:] (6 pairs, _allow_late_restart=False):
+          started calls:  T F                  (True at pair 0 = challenger start; pair 1 = no leg-0 restart)
+          finished_leg:   T T T T              (TP1 TP2 TP3 TP4 → task complete; pair 5 at leg=4 skipped)
+        """
+        task = self._load_task()
+        trace = [self._make_fix(i) for i in range(10)]
+
+        started_values = [True, False, False, True, False, False, False, False, False,
+                          True, False]
+        finished_leg_values = [True, False, False, False, False, False, False,
+                               True, True, True, True]
+
+        with patch.object(task, 'started', side_effect=started_values), \
+             patch.object(task, 'finished_leg', side_effect=finished_leg_values):
+            fixes, outlanding_fix = task.determine_trip_fixes(trace)
+
+        self.assertEqual(fixes[0], trace[3], 'restart fix should be the start fix')
+        self.assertIsNone(outlanding_fix)
+        self.assertEqual(len(fixes), 5)
+        self.assertGreater(
+            sum(task.determine_trip_distances(fixes, None)),
+            0,
+        )
+
+    def test_first_attempt_wins_when_further_along(self):
+        """
+        Case 3: pilot starts, rounds TP1 and TP2, restarts, but only reaches mid-leg-1.
+        The first attempt scores because it achieved more distance.
+
+        Main evaluation (9 pairs):
+          started:      T F F T F F F F F   (pair 0 = start; pair 3 = candidate at leg 2)
+          finished_leg: T T F F F F F        (pair 1 = TP1, pair 2 = TP2; rest False → outlanding leg 2)
+
+        Challenger trace[3:] (6 pairs, _allow_late_restart=False):
+          started:      T F F F F F          (pair 0 = challenger start; pairs 1-5 = no leg-0 restart)
+          finished_leg: F F F F F            (challenger completes 0 legs → outlanding leg 0)
+        """
+        task = self._load_task()
+        trace = [self._make_fix(i) for i in range(10)]
+
+        started_values = [True, False, False, True, False, False, False, False, False,
+                          True, False, False, False, False, False]
+        finished_leg_values = [True, True, False, False, False, False, False,
+                               False, False, False, False, False]
+
+        with patch.object(task, 'started', side_effect=started_values), \
+             patch.object(task, 'finished_leg', side_effect=finished_leg_values):
+            fixes, outlanding_fix = task.determine_trip_fixes(trace)
+
+        self.assertEqual(fixes[0], trace[0], 'original start fix should be used')
+        self.assertEqual(len(fixes), 3,
+                         'start + TP1 + TP2 should be in fixes (2 completed legs)')
+        first_attempt_distance = sum(task.determine_trip_distances(fixes, outlanding_fix))
+        self.assertGreater(first_attempt_distance, 0)
+
+    def test_incidental_start_crossing_mid_task_does_not_interrupt_completion(self):
+        """
+        Case 6: pilot crosses the start area incidentally between TP2 and TP3 while flying
+        the full task. The full task still completes; the incidental crossing is NOT a reset.
+
+        Main evaluation (9 pairs):
+          started:      T F F T F F             (pair 0 = start; pair 3 = incidental crossing at leg 2)
+          finished_leg: T T T T                  (TP1 TP2 TP3 TP4 → task complete; pairs 6-8 at leg=4 skipped)
+
+        Challenger trace[3:] (6 pairs, _allow_late_restart=False):
+          started:      T F                      (pair 0 = challenger start)
+          finished_leg: T T F F F                (challenger only completes TP1+TP2 → outlanding)
+        """
+        task = self._load_task()
+        trace = [self._make_fix(i) for i in range(10)]
+
+        started_values = [True, False, False, True, False, False,
+                          True, False]
+        finished_leg_values = [True, True, True, True,
+                               True, True, False, False, False]
+
+        with patch.object(task, 'started', side_effect=started_values), \
+             patch.object(task, 'finished_leg', side_effect=finished_leg_values):
+            fixes, outlanding_fix = task.determine_trip_fixes(trace)
+
+        self.assertEqual(len(fixes), 5, 'task should be completed despite incidental crossing')
+        self.assertIsNone(outlanding_fix)
+        self.assertEqual(fixes[0], trace[0], 'original start should be used')
+
+    def test_start_after_task_completion_is_ignored(self):
+        """
+        Cases 4 & 5: once the task is fully completed (leg == no_legs), the condition
+        `0 < leg < no_legs` is False, so started() is never evaluated and no restart
+        candidate is collected. The completed result is returned unchanged.
+
+        Main evaluation: task completed in pairs 0-4 (legs 0-3 each done). Pairs 5-8
+        are at leg=4=no_legs → no calls to started or finished_leg.
+        """
+        task = self._load_task()
+        trace = [self._make_fix(i) for i in range(10)]
+
+        started_values = [True, False, False, False, False]
+        finished_leg_values = [True, True, True, True]
+
+        with patch.object(task, 'started', side_effect=started_values), \
+             patch.object(task, 'finished_leg', side_effect=finished_leg_values):
+            fixes, outlanding_fix = task.determine_trip_fixes(trace)
+
+        self.assertEqual(fixes[0], trace[0])
+        self.assertEqual(len(fixes), 5)
+        self.assertIsNone(outlanding_fix)

--- a/tests/task/test_task_rules.py
+++ b/tests/task/test_task_rules.py
@@ -9,12 +9,29 @@ from tests.task.helper_functions import get_task
 class TestRestartAfterTurnpoint(unittest.TestCase):
     """
     FAI SC3A §7.4.3.6: multiple valid starts → scored using the start that yields the best score.
-    A start made after a properly completed task is not valid.
+    A start after a properly completed task is not valid.
 
     Tests call determine_trip_fixes directly with mocked started/finished_leg so that
     the control-flow scenarios can be driven without needing real IGC flight geometry.
-    The side_effect lists are ordered by the exact call sequence produced by the implementation:
-      - main evaluation calls first, then challenger sub-evaluation calls.
+
+    Mock call convention
+    --------------------
+    started(f1, f2) is called once per pair when:
+      - leg == -1: every pair, waiting for the first start
+      - leg == 0:  every pair, checking for a leg-0 restart (unconditional `if`)
+      - 0 < leg < no_legs AND _allow_late_restart=True: checking for a late restart candidate
+
+    finished_leg(leg, f1, f2) is called once per pair when:
+      - leg == 0: always, in a separate `if` block that runs regardless of whether started() fired
+      - 0 < leg < no_legs AND started() returned False: in the `elif` branch, so NOT called
+        when started() returned True on the same pair
+      - Never at leg == -1 (before start) or leg == no_legs (task complete)
+
+    When _allow_late_restart=False (challenger sub-evaluations): started() is not called at
+    leg > 0, so finished_leg() fires at every pair in that range.
+
+    The side_effect lists are ordered by the exact call sequence: main evaluation first,
+    then challenger sub-evaluation (if any).
     """
 
     cwd = os.path.dirname(__file__)
@@ -39,13 +56,31 @@ class TestRestartAfterTurnpoint(unittest.TestCase):
         Case 2: pilot starts, rounds TP1, turns back, restarts, then completes the task.
         The restart attempt scores because it achieves the full task distance.
 
-        Main evaluation (9 pairs over 10 fixes):
-          started calls:  T F F T F F F F F   (True at pair 0 = first start; True at pair 3 = candidate)
-          finished_leg:   T F F F F F F        (True at pair 1 = TP1 in main; rest False → outlanding leg 1)
+        Main evaluation — trace[0:] (9 pairs):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        first start → fixes=[trace[0]], leg=0
+             1    0   False      True       no restart; TP1 → leg=1
+             2    1   False      False
+             3    1    True        —        late start → candidate at pair_idx=3
+             4    1   False      False
+             5    1   False      False
+             6    1   False      False
+             7    1   False      False
+             8    1   False      False
+          Original result: outlanding on leg 1
 
-        Challenger sub-trace = trace[3:] (6 pairs, _allow_late_restart=False):
-          started calls:  T F                  (True at pair 0 = challenger start; pair 1 = no leg-0 restart)
-          finished_leg:   T T T T              (TP1 TP2 TP3 TP4 → task complete; pair 5 at leg=4 skipped)
+        Challenger — trace[3:] (6 pairs, _allow_late_restart=False):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        start → leg=0
+             1    0   False      True       no restart; TP1 → leg=1
+             2    1     —        True       TP2 → leg=2  (started not called: _allow_late_restart=False)
+             3    2     —        True       TP3 → leg=3
+             4    3     —        True       TP4 → leg=4=no_legs, task complete
+             5    4     —          —        task done, no branch matches
+          Challenger result: task complete → wins
+
+        → started_values (11): main 9 + challenger 2
+        → finished_leg   (11): main 7 (pairs 0 and 3 skipped) + challenger 4 (pairs 0 and 5 skipped)
         """
         task = self._load_task()
         trace = [self._make_fix(i) for i in range(10)]
@@ -72,13 +107,31 @@ class TestRestartAfterTurnpoint(unittest.TestCase):
         Case 3: pilot starts, rounds TP1 and TP2, restarts, but only reaches mid-leg-1.
         The first attempt scores because it achieved more distance.
 
-        Main evaluation (9 pairs):
-          started:      T F F T F F F F F   (pair 0 = start; pair 3 = candidate at leg 2)
-          finished_leg: T T F F F F F        (pair 1 = TP1, pair 2 = TP2; rest False → outlanding leg 2)
+        Main evaluation — trace[0:] (9 pairs):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        first start → leg=0
+             1    0   False      True       no restart; TP1 → leg=1
+             2    1   False      True       TP2 → leg=2
+             3    2    True        —        late start → candidate at pair_idx=3
+             4    2   False      False
+             5    2   False      False
+             6    2   False      False
+             7    2   False      False
+             8    2   False      False
+          Original result: outlanding on leg 2 (TP1 + TP2 rounded)
 
-        Challenger trace[3:] (6 pairs, _allow_late_restart=False):
-          started:      T F F F F F          (pair 0 = challenger start; pairs 1-5 = no leg-0 restart)
-          finished_leg: F F F F F            (challenger completes 0 legs → outlanding leg 0)
+        Challenger — trace[3:] (6 pairs, _allow_late_restart=False):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        start → leg=0
+             1    0   False      False      no restart; no TP1
+             2    0   False      False
+             3    0   False      False
+             4    0   False      False
+             5    0   False      False
+          Challenger result: outlanding on leg 0 (~0 km; all fixes share same lat/lon)
+
+        → started_values (15): main 9 + challenger 6
+        → finished_leg   (12): main 7 (pairs 0 and 3 skipped) + challenger 5 (pair 0 skipped)
         """
         task = self._load_task()
         trace = [self._make_fix(i) for i in range(10)]
@@ -103,13 +156,31 @@ class TestRestartAfterTurnpoint(unittest.TestCase):
         Case 6: pilot crosses the start area incidentally between TP2 and TP3 while flying
         the full task. The full task still completes; the incidental crossing is NOT a reset.
 
-        Main evaluation (9 pairs):
-          started:      T F F T F F             (pair 0 = start; pair 3 = incidental crossing at leg 2)
-          finished_leg: T T T T                  (TP1 TP2 TP3 TP4 → task complete; pairs 6-8 at leg=4 skipped)
+        Main evaluation — trace[0:] (9 pairs):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        first start → leg=0
+             1    0   False      True       no restart; TP1 → leg=1
+             2    1   False      True       TP2 → leg=2
+             3    2    True        —        incidental crossing → candidate at pair_idx=3
+             4    2   False      True       TP3 → leg=3
+             5    3   False      True       TP4 → leg=4=no_legs, task complete
+             6    4     —          —        task done
+             7    4     —          —
+             8    4     —          —
+          Original result: task complete (outlanding_fix=None)
 
-        Challenger trace[3:] (6 pairs, _allow_late_restart=False):
-          started:      T F                      (pair 0 = challenger start)
-          finished_leg: T T F F F                (challenger only completes TP1+TP2 → outlanding)
+        Challenger — trace[3:] (6 pairs, _allow_late_restart=False):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        start → leg=0
+             1    0   False      True       no restart; TP1 → leg=1
+             2    1     —        True       TP2 → leg=2
+             3    2     —        False
+             4    2     —        False
+             5    2     —        False
+          Challenger result: outlanding on leg 2 → original (full task) wins
+
+        → started_values (8): main 6 (pairs 6-8 at leg=no_legs skipped) + challenger 2
+        → finished_leg   (9): main 4 (pairs 0, 3, 6, 7, 8 skipped) + challenger 5 (pair 0 skipped)
         """
         task = self._load_task()
         trace = [self._make_fix(i) for i in range(10)]
@@ -133,8 +204,21 @@ class TestRestartAfterTurnpoint(unittest.TestCase):
         `0 < leg < no_legs` is False, so started() is never evaluated and no restart
         candidate is collected. The completed result is returned unchanged.
 
-        Main evaluation: task completed in pairs 0-4 (legs 0-3 each done). Pairs 5-8
-        are at leg=4=no_legs → no calls to started or finished_leg.
+        Main evaluation — trace[0:] (9 pairs):
+          pair  leg  started  finished_leg  note
+             0   -1    True        —        first start → leg=0
+             1    0   False      True       no restart; TP1 → leg=1
+             2    1   False      True       TP2 → leg=2
+             3    2   False      True       TP3 → leg=3
+             4    3   False      True       TP4 → leg=4=no_legs, task complete
+             5    4     —          —        0<4<4 is False → started() never called; no candidates
+             6    4     —          —
+             7    4     —          —
+             8    4     —          —
+          No restart candidates → no challengers.
+
+        → started_values (5): pairs 5-8 at leg=no_legs generate no calls
+        → finished_leg   (4): pair 0 (leg=-1) skipped
         """
         task = self._load_task()
         trace = [self._make_fix(i) for i in range(10)]


### PR DESCRIPTION
## Summary

Fixes #64.

When a pilot crosses the start, rounds a turnpoint, and then restarts, opensoar previously scored the first crossing instead of the one yielding the best score. This violates FAI SC3A §7.4.3.6: *"In the case of multiple valid Starts, the competitor has the right to be scored using the Start that yields the best score. A Start made after a properly completed Task will not be considered valid."*

### Approach: parallel challengers

Rather than resetting the current evaluation on a late start crossing (which would break case 6 below), the implementation collects each late start as a *challenger* trace index. After the main loop, each challenger is evaluated on `trace[restart_idx:]` without further restart detection (`_allow_late_restart=False`). The attempt with the highest total scored distance (kilometres) is returned.

### Behaviour by case

| # | Scenario | Result |
|---|---|---|
| 1 | Start → complete task | Scored (unchanged) |
| 2 | Start → TP1 → restart → complete further | Challenger (restart) wins |
| 3 | Start → TP1 → mid leg 2 → restart → only halfway leg 1 | Original wins |
| 4 | Start → complete → restart | First scored (restart after completion: `leg == no_legs` so no candidate collected) |
| 5 | Start → complete → restart → finish faster | First scored (same mechanism as 4) |
| 6 | Start → TP1 → TP2 → cross start line → TP3 → TP4 → finish | Full task scored (original wins over partial challenger) |

### Files changed

- `opensoar/task/race_task.py` — `determine_trip_fixes`: collect candidates instead of resetting; compare challengers by total distance
- `opensoar/task/aat.py` — `_get_sector_fixes` / `_calculate_trip_fixes`: same pattern; challenger comparison runs the full distance-optimisation pipeline on the sub-trace
- `tests/task/test_task_rules.py` — new file; four unit tests covering all six cases using mocked `started`/`finished_leg` call sequences

## Test plan

- [ ] `python -m unittest tests.task.test_task_rules -v` — all 4 new tests pass
- [ ] `python -m unittest discover -b --start-directory ./tests` — all 89 tests pass (verified locally)